### PR TITLE
fixed link for "no license traps" card

### DIFF
--- a/website/pages/welcome/welcome.asciidoc
+++ b/website/pages/welcome/welcome.asciidoc
@@ -63,7 +63,7 @@ What makes devonfw different::
 * image:/images/icons8-licence.png[]
   ** No license traps
   ** An open source platform providing transparency, ability and community support.
-  ** <</website/pages/docs/general-contributing.asciidoc_oss-compliance.html#, Learn more>>
+  ** <</website/pages/docs/general-compliance.asciidoc.html#, Learn more>>
 
 [.custom-card]
 * image:/images/icons8-product_documents.png[]


### PR DESCRIPTION
Now linking to the correct OSS Compliance page [here](https://devonfw.com/website/pages/docs/general-compliance.asciidoc.html).