### PR TITLE
rework contents of explore website section

### DIFF
--- a/asciidoctor-backend/erb/html5/document.html.erb
+++ b/asciidoctor-backend/erb/html5/document.html.erb
@@ -176,6 +176,11 @@ unless nofooter %>
         console.log(document.querySelector('.website-navbar ul'))
       })
     </script>
+    <script type="module">
+      import { EditLinksModule } from '/website/shared/editlinks.js';
+
+      EditLinksModule.addEditLinks();
+    </script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
       integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"

--- a/asciidoctor-backend/erb/html5/document.html.erb
+++ b/asciidoctor-backend/erb/html5/document.html.erb
@@ -93,6 +93,8 @@ end
 #{docinfo_content}) %>
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
+<script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
+
 <!-- ************** Google analytics ************ -->
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -196,5 +198,8 @@ end %><%= (docinfo_content = (docinfo :footer)).empty? ? nil : %(
 </div>
 </div><%
 end %>
+<script>
+   anchors.add();
+</script>
 </body>
 </html>

--- a/asciidoctor-backend/erb/html5/document.html.erb
+++ b/asciidoctor-backend/erb/html5/document.html.erb
@@ -204,7 +204,8 @@ end %><%= (docinfo_content = (docinfo :footer)).empty? ? nil : %(
 </div><%
 end %>
 <script>
-   anchors.add();
+  anchors.options.visible = 'always';
+  anchors.add();
 </script>
 </body>
 </html>

--- a/asciidoctor-stylesheet/sass/pages/docs.scss
+++ b/asciidoctor-stylesheet/sass/pages/docs.scss
@@ -161,3 +161,12 @@ body.book.toc2.toc-left {
     }
   }
 }
+.edit-link {
+  font-size: 1em;
+  color: #222222;
+}
+
+.anchorjs-link {
+  font-size: 1em;
+  color: #222222;
+}

--- a/website/pages/explore/dir-tree/component.js
+++ b/website/pages/explore/dir-tree/component.js
@@ -145,9 +145,9 @@ class DirTree extends HTMLDivElement {
         const editUrl = `https://github.com/devonfw/devonfw.github.io/edit/develop/website/pages/explore/dir-content/${asciidocFilename}`;
         const commonLinks = addTarget(aux.find('.common-links a'));
         const devon4jLinks = addTarget(aux.find('.devon4j-links a'));
-        const devon4netLinks = addTarget(aux.find('.devon4j-links a'));
-        const devon4ngLinks = addTarget(aux.find('.devon4j-links a'));
-        const devon4nodeLinks = addTarget(aux.find('.devon4j-links a'));
+        const devon4netLinks = addTarget(aux.find('.devon4net-links a'));
+        const devon4ngLinks = addTarget(aux.find('.devon4ng-links a'));
+        const devon4nodeLinks = addTarget(aux.find('.devon4node-links a'));
         const videosLinks = aux.find('.videos-links a');
         
         if(text != "" || 

--- a/website/pages/explore/dir-tree/component.js
+++ b/website/pages/explore/dir-tree/component.js
@@ -72,9 +72,12 @@ class DirTree extends HTMLDivElement {
     function detailsTemplate(fileInfo) {
       let details = `
         <div class="col-12 col-sm-8">
-          <a href="${fileInfo.url}" class="d-flex align-items-center td-hover-none">
-            <h4 class="font-weight-bold mb-0 details-title">${fileInfo.title}</h4><div class="custom-bullet forward-arrow ml-3"></div>
-          </a>
+          <div class="d-flex align-items-center td-hover-none">
+            <a href="${fileInfo.url}"  class="d-flex td-hover-none">
+              <h4 class="font-weight-bold mb-0 details-title">${fileInfo.title}</h4>
+            </a>
+            <a href="${fileInfo.editUrl}" class="d-flex td-hover-none edit-link" target="_blank" title="This will open the corresponding asciidoc file in the github editor and create a PullRequest for your changes when you save them. The changes will be reviewed before they are published on the website.">&#x270E</a>
+          </div>
           <p class="mt-4 pt-1 details-content">${fileInfo.text}</p>
         </div>
         <div class="col-12 col-sm-4 details-references">
@@ -138,6 +141,8 @@ class DirTree extends HTMLDivElement {
         const title = dir.find('h2').text();
         const text = getText(dir);
         const url = `${path.dir}/${path.file}`;
+        let asciidocFilename = path.file.replace(".html",".asciidoc");
+        const editUrl = `https://github.com/devonfw/devonfw.github.io/edit/develop/website/pages/explore/dir-content/${asciidocFilename}`;
         const commonLinks = addTarget(aux.find('.common-links a'));
         const devon4jLinks = addTarget(aux.find('.devon4j-links a'));
         const devon4netLinks = addTarget(aux.find('.devon4j-links a'));
@@ -152,7 +157,7 @@ class DirTree extends HTMLDivElement {
           devon4ngLinks.length != 0 ||
           devon4nodeLinks.length != 0 ||
           videosLinks.length != 0 ) {
-          const fileInfo = { title, text, url };
+          const fileInfo = { title, text, url, editUrl};
           const details = detailsTemplate(fileInfo);
           $('.dir-component .dir-tree-detail').html(details);
           setHtmlOrHide('details-links', commonLinks);
@@ -184,7 +189,7 @@ class DirTree extends HTMLDivElement {
     function showDirInfo(aux2, el, lvl, parentFile) {
       return () => {
         const dir = aux2.find('.directory');
-        const links = aux2.find('.links-to-files');
+        const links = aux2.find('.links-to-files a');
         const title = dir.find('h2').text();
         const text = getText(dir);
         let listItem = getLiDir(title, el, lvl + 1, parentFile);

--- a/website/pages/explore/dir-tree/component.js
+++ b/website/pages/explore/dir-tree/component.js
@@ -78,12 +78,36 @@ class DirTree extends HTMLDivElement {
           <p class="mt-4 pt-1 details-content">${fileInfo.text}</p>
         </div>
         <div class="col-12 col-sm-4 details-references">
-          <h4>Links</h4>
-          <p class="details-links custom-col">
-          </p>
-          <h4 class="mt-4">Videos</h4>
-          <p class="details-videos custom-col">
-          </p>
+          <div id="details-links">
+            <h4>Links</h4>
+            <p class="details-links custom-col">
+            </p>
+          </div>
+          <div id="details-links-devon4j">
+            <h4>Links devon4j</h4>
+            <p class="details-links-devon4j custom-col">
+            </p>
+          </div>
+          <div id="details-links-devon4net">
+            <h4>Links devon4net</h4>
+            <p class="details-links-devon4net custom-col">
+            </p>
+          </div>
+          <div id="details-links-devon4ng">
+            <h4>Links devon4ng</h4>
+            <p class="details-links-devon4ng custom-col">
+            </p>
+          </div>
+          <div id="details-links-devon4node">
+            <h4>Links devon4node</h4>
+            <p class="details-links-devon4node custom-col">
+            </p>
+          </div>
+          <div id="details-videos">
+            <h4 class="mt-4">Videos</h4>
+            <p class="details-videos custom-col">
+            </p>
+          </div>
         </div>
       `;
 
@@ -114,15 +138,47 @@ class DirTree extends HTMLDivElement {
         const title = dir.find('h2').text();
         const text = getText(dir);
         const url = `${path.dir}/${path.file}`;
-        const commonLinks = aux.find('.common-links a');
+        const commonLinks = addTarget(aux.find('.common-links a'));
+        const devon4jLinks = addTarget(aux.find('.devon4j-links a'));
+        const devon4netLinks = addTarget(aux.find('.devon4j-links a'));
+        const devon4ngLinks = addTarget(aux.find('.devon4j-links a'));
+        const devon4nodeLinks = addTarget(aux.find('.devon4j-links a'));
         const videosLinks = aux.find('.videos-links a');
-
-        const fileInfo = { title, text, url };
-        const details = detailsTemplate(fileInfo);
-        $('.dir-component .dir-tree-detail').html(details);
-        $('.dir-component .details-links').html(commonLinks);
-        $('.dir-component .details-videos').html(videosLinks);
+        
+        if(text != "" || 
+          commonLinks.length != 0 || 
+          devon4jLinks.length != 0 ||
+          devon4netLinks.length != 0 ||
+          devon4ngLinks.length != 0 ||
+          devon4nodeLinks.length != 0 ||
+          videosLinks.length != 0 ) {
+          const fileInfo = { title, text, url };
+          const details = detailsTemplate(fileInfo);
+          $('.dir-component .dir-tree-detail').html(details);
+          setHtmlOrHide('details-links', commonLinks);
+          setHtmlOrHide('details-links-devon4j', devon4jLinks);
+          setHtmlOrHide('details-links-devon4net', devon4netLinks);
+          setHtmlOrHide('details-links-devon4ng', devon4ngLinks);
+          setHtmlOrHide('details-links-devon4node', devon4nodeLinks);
+          setHtmlOrHide('details-videos', videosLinks);
+        }
+        else {
+          $('.dir-component .dir-tree-detail').html('');
+        }
       });
+    }
+
+    function setHtmlOrHide(name, value) {
+      if(value.length > 0){
+        $('.dir-component .' + name).html(value);
+      }
+      else {
+        $('.dir-component #' + name).hide();
+      }
+    }
+
+    function addTarget(links){
+      return links.each((_,e) => e.target = '_blank');
     }
 
     function showDirInfo(aux2, el, lvl, parentFile) {
@@ -144,7 +200,7 @@ class DirTree extends HTMLDivElement {
 
     function getText(dir) {
       return dir
-        .find('p')
+        .find('.sectionbody > .paragraph p')
         .map((_, el) => $(el).text() + '<br/>')
         .get()
         .join('');
@@ -181,6 +237,10 @@ class DirTree extends HTMLDivElement {
             lvlDest,
           );
         }
+        showFileDetails({
+          dir: './dir-content',
+          file: $(el).attr('href'),
+        });
       }
 
       const dir = $(dirTemplate(text)).click(clickHandler);

--- a/website/pages/explore/explore.css
+++ b/website/pages/explore/explore.css
@@ -46,3 +46,8 @@
 .custom-bullet.forward-arrow {
   background-image: url(./dir-tree/icons/ic_folder_forward.svg);
 }
+
+.edit-link {
+  font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+  font-size: 28px;
+}

--- a/website/pages/explore/explore.css
+++ b/website/pages/explore/explore.css
@@ -49,5 +49,6 @@
 
 .edit-link {
   font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
-  font-size: 28px;
+  font-size: 1.5rem;
+  color: #222222;
 }

--- a/website/shared/editlinks.js
+++ b/website/shared/editlinks.js
@@ -1,0 +1,180 @@
+const editLinksModule = (function(window) {
+  // Function definitions
+
+  function getRepoName() {
+
+    let rules = [
+        {
+            re: /guide-([^\/]+?)\.asciidoc/,
+            value: 'devonfw-guide'
+        },
+        {
+            re: /master-contributing\.asciidoc/,
+            value: 'devonfw-guide'
+        },
+        {
+            re: /master-database\.asciidoc/,
+            value: 'devonfw-guide'
+        },
+        {
+            re: /devonfw-ide-([^\/]+?)\.asciidoc/,
+            value: 'ide'
+        },
+        {
+            re: /(master-)?release-notes([^\/]+?)\.asciidoc/,
+            value: undefined
+        },
+        {
+            re: /User-Stories\.asciidoc/,
+            value: undefined
+        },
+        {
+            re: /dsf-how-to-use\.asciidoc/,
+            value: undefined
+        },
+        {
+            re: /(master-)?([^\/]+?)\.asciidoc/,
+            index: 2
+        }
+    ]
+    let repoName;
+    rules.some(rule => {
+        let matches = rule.re.exec(window.location.pathname);
+        if(matches){
+            if(rule.index !== undefined){
+                repoName = matches[rule.index];
+            } else {
+                repoName = rule.value;
+            }
+            return true;
+        }
+        return false;
+    });
+
+    return repoName; 
+  }
+
+  function getFolderName() {
+
+    let rules = [
+        {
+            re: /guide-([^\/]+?)\.asciidoc/,
+            value: 'general/db'
+        },
+        {
+            re: /master-contributing\.asciidoc/,
+            value: 'general'
+        },
+        {
+            re: /master-database\.asciidoc/,
+            value: 'general/db'
+        },
+        {
+            re: /devonfw-ide-([^\/]+?)\.asciidoc/,
+            value: 'documentation'
+        },
+        {
+            re: /(master-)?([^\/]+?)\.asciidoc/,
+            value: 'documentation'
+        }
+    ]
+    let folderName;
+    rules.some(rule => {
+        let matches = rule.re.exec(window.location.pathname);
+        if(matches){
+            if(rule.index !== undefined){
+                folderName = matches[rule.index];
+            } else {
+                folderName = rule.value;
+            }
+            return true;
+        }
+        return false;
+    });
+
+    return folderName; 
+  }
+
+  function getBranchName() {
+
+    let rules = [
+        {
+            re: /guide-([^\/]+?)\.asciidoc/,
+            value: 'master'
+        },
+        {
+            re: /master-contributing\.asciidoc/,
+            value: 'master'
+        },
+        {
+            re: /master-database\.asciidoc/,
+            value: 'master'
+        },
+        {
+            re: /devonfw-ide-([^\/]+?)\.asciidoc/,
+            value: 'master'
+        },
+        {
+            re: /master-cobigen\.asciidoc/,
+            value: 'master'
+        },
+        {
+            re: /master-production-line\.asciidoc/,
+            value: 'master'
+        },
+        {
+            re: /(master-)?([^\/]+?)\.asciidoc/,
+            value: 'develop'
+        }
+    ]
+    let branchName;
+    rules.some(rule => {
+        let matches = rule.re.exec(window.location.pathname);
+        if(matches){
+            if(rule.index !== undefined){
+                branchName = matches[rule.index];
+            } else {
+                branchName = rule.value;
+            }
+            return true;
+        }
+        return false;
+    });
+
+    return branchName; 
+  }
+
+  function addEditLinks() {    
+    let title = 'This will open the corresponding asciidoc file in the github editor and create a PullRequest for your changes when you save them. The changes will be reviewed before they are published on the website.';
+
+    let repoName = getRepoName(); 
+
+    if(repoName) {
+        let folderName = getFolderName();
+        let branchName = getBranchName();
+        let urlPrefix = "https://github.com/devonfw/" + repoName + "/edit/" + branchName + "/" + folderName + "/";
+        $('h3,h4,h5').each(function() {
+            let headline = $( this );
+            let id = headline.prop('id');
+            let re = /^.+?\.asciidoc/;
+            let matches = re.exec(id);
+            let filename = matches[0];
+            let url = urlPrefix + filename;
+            var link = $('<a title="' + title + '" target="_blank" style="padding-left: 0.375em;" class="edit-link" href="' + url + '">&#x270E</a>');
+            var anchorLink = headline.find("a");
+            if(anchorLink.length){
+                anchorLink.before(link);
+            } else {
+                headline.append(link);
+            }
+        });
+    }
+  }
+
+  // List of functions accessibly by other scripts
+  return {
+    addEditLinks: addEditLinks
+  };
+})(window);
+
+export const EditLinksModule = editLinksModule;


### PR DESCRIPTION
This are preparations for the content update of the explore section.

Explore section script
- Empty sections will be hidden
- All nodes of the tree can have a text and links, not only the leafs
- Fixed the issue that the text of the links was visible in the text section, too

Docs
- Added anchor link to the headlines
- Added edit link to the headlines