### PR TITLE
#120: Fixed results without body

### DIFF
--- a/website/pages/search-results/search-results.js
+++ b/website/pages/search-results/search-results.js
@@ -32,6 +32,9 @@ function getSnippets(occMap, range, text) {
   // for each word in the search query
   for (let i = 0; i < occurrencesKeys.length; i++) {
     let key = occurrencesKeys[i];
+    if(!occurrencesMap[key].body){
+      return '';
+    }
     let ocurrences = occurrencesMap[key].body.position;
 
     // for each ocurrence of a word


### PR DESCRIPTION
There was an error when the result body was empty. This could e.g. happen when an explore section entry has no text and only links.