### PR TITLE
Copied solutions from Stack repository to architecture solutions folder

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,6 +45,13 @@ jobs:
           node renamer.js ../devonfw-guide/ Home .asciidoc
           cd ..
 
+      - name: Solutions from Stack repositories
+        run: |
+          cd architectures/scripts
+          npm install 
+          node copySolutionsFromStack.js ../../devonfw-guide
+          cd ..
+
       - name: Copy pom files for architectures
         run: |
           chmod +x architectures/scripts/copyPomFiles.sh

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,7 +50,7 @@ jobs:
           cd architectures/scripts
           npm install 
           node copySolutionsFromStack.js ../../devonfw-guide
-          cd ..
+          cd ../../
 
       - name: Copy pom files for architectures
         run: |


### PR DESCRIPTION
Copied the "solutions" folder from every submodule of the"devonfw-guide" repository to the architecture solutions folder. (Only if such a folder exists)

closes #158 